### PR TITLE
Add async baseUrl support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 * Security upgrade cookie and parse-server ([#274](https://github.com/parse-community/parse-server-s3-adapter/issues/274)) ([4b6aadc](https://github.com/parse-community/parse-server-s3-adapter/commit/4b6aadc7244dd91d79818c7c6cf752333ee79776))
 
+### Features
+
+* Support async `baseUrl` function
+
 # [4.1.0](https://github.com/parse-community/parse-server-s3-adapter/compare/4.0.0...4.1.0) (2025-01-03)
 
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The preferred method is to use the default AWS credentials pattern.  If no AWS c
       "bucketPrefix": '', // default value
       "directAccess": false, // default value
       "fileAcl": null, // default value
-      "baseUrl": null, // default value
+      "baseUrl": null, // string, function or async function
       "baseUrlDirect": false, // default value
       "signatureVersion": 'v4', // default value
       "globalCacheControl": null, // default value. Or 'public, max-age=86400' for 24 hrs Cache-Control
@@ -227,7 +227,7 @@ var s3Options = {
   "region": 'us-east-1', // default value
   "bucketPrefix": '', // default value
   "directAccess": false, // default value
-  "baseUrl": null // default value
+  "baseUrl": null // string, function or async function
   "signatureVersion": 'v4', // default value
   "globalCacheControl": null, // default value. Or 'public, max-age=86400' for 24 hrs Cache-Control
   "presignedUrl": false, // default value

--- a/index.js
+++ b/index.js
@@ -31,13 +31,14 @@ const serialize = obj => {
   return str.join('&');
 };
 
-function buildDirectAccessUrl(baseUrl, baseUrlFileKey, presignedUrl, config, filename) {
-  let directAccessUrl;
+async function buildDirectAccessUrl(baseUrl, baseUrlFileKey, presignedUrl, config, filename) {
+  let urlBase;
   if (typeof baseUrl === 'function') {
-    directAccessUrl = `${baseUrl(config, filename)}/${baseUrlFileKey}`;
+    urlBase = await baseUrl(config, filename);
   } else {
-    directAccessUrl = `${baseUrl}/${baseUrlFileKey}`;
+    urlBase = baseUrl;
   }
+  let directAccessUrl = `${urlBase}/${baseUrlFileKey}`;
 
   if (presignedUrl) {
     directAccessUrl += presignedUrl.substring(presignedUrl.indexOf('?'));
@@ -246,7 +247,7 @@ class S3Adapter {
     }
 
     const baseUrlFileKey = this._baseUrlDirect ? fileName : fileKey;
-    return buildDirectAccessUrl(this._baseUrl, baseUrlFileKey, presignedUrl, config, filename);
+    return await buildDirectAccessUrl(this._baseUrl, baseUrlFileKey, presignedUrl, config, filename);
   }
 
   async handleFileStream(filename, req, res) {

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -640,6 +640,40 @@ describe('S3Adapter tests', () => {
     });
   });
 
+  describe('getFileLocation with async baseUrl', () => {
+    const testConfig = {
+      mount: 'http://my.server.com/parse',
+      applicationId: 'xxxx',
+    };
+    let options;
+
+    beforeEach(() => {
+      options = {
+        directAccess: true,
+        bucketPrefix: 'foo/bar/',
+        baseUrl: async () => {
+          await Promise.resolve();
+          return 'http://example.com/files';
+        },
+      };
+    });
+
+    it('should await async baseUrl', async () => {
+      const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
+      await expectAsync(s3.getFileLocation(testConfig, 'test.png')).toBeResolvedTo(
+        'http://example.com/files/foo/bar/test.png'
+      );
+    });
+
+    it('should direct to async baseUrl when baseUrlDirect', async () => {
+      options.baseUrlDirect = true;
+      const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
+      await expectAsync(s3.getFileLocation(testConfig, 'test.png')).toBeResolvedTo(
+        'http://example.com/files/test.png'
+      );
+    });
+  });
+
   describe('validateFilename', () => {
     let options;
 


### PR DESCRIPTION
## Summary
- support async `baseUrl` values when building custom file URLs
- document that `baseUrl` may be async
- test using async `baseUrl`

## Testing
- `npm test` *(fails: `mongodb-runner: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b5e7cc160832daf632445f4eec96b